### PR TITLE
lab3

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,13 +3,10 @@ on:
   push:
     branches: [ "main" ]  
   pull_request:
-    types: [opened, synchronize, reopened]
     branches: [ "main" ]
   workflow_dispatch:
-
 permissions:
   pull-requests: read
-
 jobs:
   sonar-check:
     name: Sonar Check
@@ -25,6 +22,25 @@ jobs:
       - name: Restore
         run: dotnet restore NetSdrClient.sln
         
+      - name: Test with Coverage
+        run: dotnet test NetSdrClient.sln -c Release --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        
+      - name: Prepare Coverage for SonarCloud
+        run: |
+          $coverageFile = Get-ChildItem -Path ./TestResults -Recurse -Filter "coverage.cobertura.xml" | Select-Object -First 1
+          if ($coverageFile) {
+            Write-Host "Found coverage file: $($coverageFile.FullName)"
+            echo "COVERAGE_FILE=$($coverageFile.FullName)" >> $env:GITHUB_ENV
+          }
+        shell: pwsh
+        
+      - name: Convert Coverage to SonarQube format
+        run: |
+          dotnet tool install -g dotnet-reportgenerator-globaltool
+          reportgenerator "-reports:${{ env.COVERAGE_FILE }}" "-targetdir:./CoverageReport" "-reporttypes:SonarQube"
+          echo "SONAR_COVERAGE_FILE=./CoverageReport/SonarQube.xml" >> $env:GITHUB_ENV
+        shell: pwsh
+          
       - name: SonarScanner Begin
         run: |
           dotnet tool install --global dotnet-sonarscanner
@@ -34,21 +50,17 @@ jobs:
             /o:"8540675-star" `
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" `
             /d:sonar.host.url="https://sonarcloud.io" `
-            /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.cobertura.xml" `
+            /d:sonar.coverageReportPaths="${{ env.SONAR_COVERAGE_FILE }}" `
             /d:sonar.coverage.exclusions=**/Program.cs `
             /d:sonar.cpd.cs.minimumTokens=40 `
             /d:sonar.cpd.cs.minimumLines=5 `
-            /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/**
+            /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/** `
+            /d:sonar.qualitygate.wait=false
         shell: pwsh
         
       - name: Build
         run: dotnet build NetSdrClient.sln -c Release --no-restore
         
-      - name: Test with Coverage
-        run: dotnet test NetSdrClient.sln -c Release --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults
-        
       - name: SonarScanner End
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         shell: pwsh

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,12 +38,7 @@ jobs:
             /d:sonar.coverage.exclusions=**/Program.cs `
             /d:sonar.cpd.cs.minimumTokens=40 `
             /d:sonar.cpd.cs.minimumLines=5 `
-<<<<<<< HEAD
             /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/**
-=======
-            /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/** `
-            /d:sonar.qualitygate.wait=true
->>>>>>> a22326d0231c5904268c81f898929740f8db72fe
         shell: pwsh
         
       - name: Build

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,10 +3,13 @@ on:
   push:
     branches: [ "main" ]  
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [ "main" ]
   workflow_dispatch:
+
 permissions:
   pull-requests: read
+
 jobs:
   sonar-check:
     name: Sonar Check
@@ -22,25 +25,6 @@ jobs:
       - name: Restore
         run: dotnet restore NetSdrClient.sln
         
-      - name: Test with Coverage
-        run: dotnet test NetSdrClient.sln -c Release --collect:"XPlat Code Coverage" --results-directory ./TestResults
-        
-      - name: Prepare Coverage for SonarCloud
-        run: |
-          $coverageFile = Get-ChildItem -Path ./TestResults -Recurse -Filter "coverage.cobertura.xml" | Select-Object -First 1
-          if ($coverageFile) {
-            Write-Host "Found coverage file: $($coverageFile.FullName)"
-            echo "COVERAGE_FILE=$($coverageFile.FullName)" >> $env:GITHUB_ENV
-          }
-        shell: pwsh
-        
-      - name: Convert Coverage to SonarQube format
-        run: |
-          dotnet tool install -g dotnet-reportgenerator-globaltool
-          reportgenerator "-reports:${{ env.COVERAGE_FILE }}" "-targetdir:./CoverageReport" "-reporttypes:SonarQube"
-          echo "SONAR_COVERAGE_FILE=./CoverageReport/SonarQube.xml" >> $env:GITHUB_ENV
-        shell: pwsh
-          
       - name: SonarScanner Begin
         run: |
           dotnet tool install --global dotnet-sonarscanner
@@ -50,17 +34,21 @@ jobs:
             /o:"8540675-star" `
             /d:sonar.token="${{ secrets.SONAR_TOKEN }}" `
             /d:sonar.host.url="https://sonarcloud.io" `
-            /d:sonar.coverageReportPaths="${{ env.SONAR_COVERAGE_FILE }}" `
+            /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.cobertura.xml" `
             /d:sonar.coverage.exclusions=**/Program.cs `
             /d:sonar.cpd.cs.minimumTokens=40 `
             /d:sonar.cpd.cs.minimumLines=5 `
-            /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/** `
-            /d:sonar.qualitygate.wait=false
+            /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/**
         shell: pwsh
         
       - name: Build
         run: dotnet build NetSdrClient.sln -c Release --no-restore
         
+      - name: Test with Coverage
+        run: dotnet test NetSdrClient.sln -c Release --no-build --collect:"XPlat Code Coverage" --results-directory ./TestResults
+        
       - name: SonarScanner End
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
         shell: pwsh

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -55,7 +55,7 @@ jobs:
             /d:sonar.cpd.cs.minimumTokens=40 `
             /d:sonar.cpd.cs.minimumLines=5 `
             /d:sonar.exclusions=**/bin/**,**/obj/**,**/sonarcloud.yml,**/TestResults/** `
-            /d:sonar.qualitygate.wait=false
+            /d:sonar.qualitygate.wait=true
         shell: pwsh
         
       - name: Build

--- a/NetSdrClient.sln
+++ b/NetSdrClient.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1


### PR DESCRIPTION
Аналіз завдання. Спочатку я проаналізував вимоги та виявив, що ключові налаштування для збору покриття тестами (пакети coverlet.msbuild та конфігурація sonarcloud.yml) вже були реалізовані під час виконання попередньої лабораторної роботи. Це дозволило мені одразу перейти до основної частини завдання — написання нових тестів.

Створення ізольованого середовища. Щоб забезпечити чистоту та безпеку основного коду, я створив нову гілку lab3, в якій вів усю подальшу роботу.

<img width="618" height="105" alt="image" src="https://github.com/user-attachments/assets/2626182e-702d-48dd-8050-275a2e081767" />



Додавання юніт-тести для класу NetSdrMessageHelper. Ці тести перевіряють ключові сценарії роботи, обробку граничних значень та коректність розбору повідомлень, що значно підвищило надійність цього модуля.
<img width="668" height="656" alt="image" src="https://github.com/user-attachments/assets/8929aa08-de27-4a9c-8455-1f14904c5baa" />

Створення та перевірка Pull Request. Після написання тестів та виправлення помилки, я створив новий Pull Request. Він успішно пройшов усі автоматичні перевірки, отримавши статус "Passed" та зелену галочку ✅, що підтверджує якість внесених змін.
<img width="968" height="488" alt="image" src="https://github.com/user-attachments/assets/583d1dd3-c408-4d04-8719-fbab197fc4cf" />
<img width="974" height="424" alt="image" src="https://github.com/user-attachments/assets/718c464f-725d-4821-8b77-29e6e357a0e0" />
<img width="941" height="275" alt="image" src="https://github.com/user-attachments/assets/cadd8938-a489-43c4-b5ba-158a321795df" />




скрін Coverage

ДО
<img width="716" height="54" alt="image" src="https://github.com/user-attachments/assets/e47977ea-9972-41b6-92f4-0973846cf241" />


ПІСЛЯ
<img width="796" height="71" alt="image" src="https://github.com/user-attachments/assets/d64141dd-455a-4d0d-bff0-b27ba75f0ced" />



























[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=coverage)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=bugs)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=8540675-star_NetSdrClient&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=8540675-star_NetSdrClient)